### PR TITLE
fix course code greater than 'S' not being caught by router

### DIFF
--- a/server/routes/pathways.js
+++ b/server/routes/pathways.js
@@ -60,7 +60,7 @@ router.get('/courses', (req, res) => {
  *   ]
  * }
  */
-router.get('/relations/:code([A-S]{4}[0-9]{4})', (req, res) => {
+router.get('/relations/:code([A-Z]{4}[0-9]{4})', (req, res) => {
   console.log("relations api call");
   db.query("SELECT DISTINCT * FROM pathways_relationships WHERE source LIKE $1 OR destination LIKE $1", [req.params.code], (err, queryRes) => {
       if (err) {

--- a/server/routes/plannify.js
+++ b/server/routes/plannify.js
@@ -2,7 +2,7 @@ var express = require('express');
 var db = require('../database/db');
 var router = express.Router();
 
-router.get('/course/:CODE([A-S]{4}[0-9]{4})', (req, res) => {
+router.get('/course/:CODE([A-Z]{4}[0-9]{4})', (req, res) => {
     db.query("SELECT * FROM course WHERE code LIKE $1",[req.params.CODE], (err, queryRes) => {
         if (err) {
             throw err;


### PR DESCRIPTION
`localhost:3001/api/relations/ACCT1501` would not be handled by router if only specify `A-S` in the regex query. To handle all course codes, `A-Z` should be specified to fix the problem