### PR TITLE
fix type error when running `server/scripts/create_psql_db.py`

### DIFF
--- a/server/scripts/create_psql_db.py
+++ b/server/scripts/create_psql_db.py
@@ -33,7 +33,7 @@ courses = [
 ]
 
 # Create Database
-conn = pg8000.connect(port=PGPORT, host=PGHOST, user=PGUSER, password=PGPASSWORD)
+conn = pg8000.connect(port=int(PGPORT), host=PGHOST, user=PGUSER, password=PGPASSWORD)
 cur = conn.cursor()
 conn.autocommit = True
 cur.execute("DROP DATABASE IF EXISTS " + DEGREE_PLANNER_DATABASE_NAME);
@@ -42,7 +42,7 @@ conn.autocommit = False
 cur.close()
 
 # Create tables
-conn = pg8000.connect(database=DEGREE_PLANNER_DATABASE_NAME, port=PGPORT, host=PGHOST, user=PGUSER, password=PGPASSWORD)
+conn = pg8000.connect(database=DEGREE_PLANNER_DATABASE_NAME, port=int(PGPORT), host=PGHOST, user=PGUSER, password=PGPASSWORD)
 cur = conn.cursor()
 cur.execute("CREATE TABLE IF NOT EXISTS faculties (name text primary key, schools text)")
 cur.execute("CREATE TABLE IF NOT EXISTS schools (name text primary key, programs text)")


### PR DESCRIPTION
When running `server/scripts/create_psql_db.py`, an type error of integer occurs:

![72616531_420025895379409_2796511622275792896_n](https://user-images.githubusercontent.com/34177142/67407825-cf042180-f603-11e9-9efa-1e0adb65b0ec.png)

This error is raised because of the PGPORT is a string but `.connect -> port` is expecting an integer. Casting it to int using `int()` works. 